### PR TITLE
Remove Simple Line Icons

### DIFF
--- a/packages/octave/lib/components/common/DefaultLayout/DefaultLayout.jsx
+++ b/packages/octave/lib/components/common/DefaultLayout/DefaultLayout.jsx
@@ -81,7 +81,6 @@ const DefaultLayout = (props) => {
         <meta name='msapplication-TileColor' content='#da532c' />
         <meta name='theme-color' content='#ffffff' />
         <script src='https://kit.fontawesome.com/085731bca6.js' crossOrigin='anonymous' />
-        <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/simple-line-icons/2.4.1/css/simple-line-icons.min.css' integrity='sha256-7O1DfUu4pybYI7uAATw34eDrgQaWGOfMV/8erfDQz/Q=' crossOrigin='anonymous' />
       </Helmet>
     )
   }


### PR DESCRIPTION
- Because we now use only fontawesome, this is leftover dead code
- Had been using the CDN (https://cdnjs.com/libraries/simple-line-icons)