### PR TITLE
Add public-testing script and settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ misc/
 node_modules/
 notes/
 packages/octave/lib/server/seeds/generated/
-scripts/
+scripts/*
+!scripts/start-public-testing.sh
 storybook-static/
 tests/cypress/integration/examples
 tests/cypress/screenshots

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start-debug": "meteor debug --port 4004 --settings settings.json",
     "start-mongo": ". scripts/start-mongo.sh",
     "start-mozart": ". scripts/start-mozart.sh",
+    "start-public-testing": ". scripts/start-public-testing.sh",
     "start-triad": ". scripts/start-triad.sh",
     "start-mongo-old": ". scripts/start-mongo-old.sh",
     "start-visualizer": "meteor --extra-packages bundle-visualizer --production --port 4004 --settings settings.json",

--- a/scripts/start-public-testing.sh
+++ b/scripts/start-public-testing.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+MONGO_URL='mongodb+srv://read-only-testing-account:valid\during\february\2021@cluster0.dk7n0.mongodb.net/Triad?retryWrites=true&w=majority' meteor --port 4004 --settings settings-triad.json

--- a/settings-public-testing.json
+++ b/settings-public-testing.json
@@ -1,0 +1,35 @@
+{
+  "public": {
+    "title": "Octave Public Testing",
+    "tagline": "Public Testing Version of Octave",
+    "homeUrl": "//example.com/",
+    "owner": "John Q. Public, LLC",
+    "ownerUrl": "//example.com/",
+    "description": "Octave is a side project that is totally awesome. This is the publicly available version with unreal data.",
+    "version": "1.16.29",
+    "faviconUrl": "/favicon/favicon.ico",
+    "locale": "en",
+    "algolia": {
+      "ApplicationID": "MHHVORPPHC",
+      "SearchOnlyAPIKey": "a4143a5dd9f9cb69d64a58c157c0f127",
+      "AlgoliaIndex": "Mockaroo",
+      "README": "Index names appear in network requests and should be considered publicly available",
+      "enableErrorDelete": true
+    },
+    "apolloSsr": {
+      "disable": true
+    },
+    "pollInterval": 30000
+  },
+  "private": {
+    "algolia": {
+      "AddAndUpdateAPIKey": "b41683f331768543c229f488ccda0984",
+      "README": "The Mockaroo Algolia index is a sandbox for development only."
+    }
+  },
+  "apolloServer": {
+    "corsWhitelist": [],
+    "corsEnableAll": false
+  },
+  "debug": true
+}


### PR DESCRIPTION
Add `start-public-testing.sh` and `settings-public-testing.json`

Start script has read-only access to the db and it exposes credentials. Don't see a way around that. GitGuardian is probably gonna trigger. We shall see.