### PR TITLE
And and patch crypto-random-string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12553,10 +12553,12 @@
       "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.0.tgz",
+      "integrity": "sha512-teWAwfMb1d6brahYyKqcBEb5Yp8PJPvPOdOonXDnvaKOTmKDFNVE8E3Y2XQuzjNV/3XMwHbrX9fHWvrhRKt4Gg==",
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "crypto-token": {
       "version": "1.0.1",
@@ -27560,8 +27562,7 @@
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -27750,6 +27751,14 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^2.0.0"
+      },
+      "dependencies": {
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+          "dev": true
+        }
       }
     },
     "unist-util-is": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "cookie-parser": "^1.4.5",
     "cross-fetch": "^3.0.6",
     "crypto-js": "^4.0.0",
+    "crypto-random-string": "^3.3.0",
     "dataloader": "^1.4.0",
     "deepmerge": "^4.2.2",
     "escape-string-regexp": "^4.0.0",

--- a/patches/crypto-random-string+3.3.0.patch
+++ b/patches/crypto-random-string+3.3.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/crypto-random-string/index.js b/node_modules/crypto-random-string/index.js
+index 9193527..325684b 100644
+--- a/node_modules/crypto-random-string/index.js
++++ b/node_modules/crypto-random-string/index.js
+@@ -1,5 +1,6 @@
+ 'use strict';
+-const {promisify} = require('util');
++// const {promisify} = require('util');
++const promisify = require('util.promisify');
+ const crypto = require('crypto');
+ 
+ const randomBytesAsync = promisify(crypto.randomBytes);


### PR DESCRIPTION
Add `crypto-random-string` after a commit to Vulcan main repo requires it
Create a patch for `crypto-random-string` to get it working 

See https://forums.meteor.com/t/meteor-node-stubs-installed-but-still-not-seeing-the-util-function-promisify/55195/2

See https://vulcanjs.slack.com/archives/C2LJQHTLP/p1611215870000100